### PR TITLE
Feature/issues 64 チーム情報の操作に関しての機能を整えました

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -14,7 +14,6 @@ class AssignsController < ApplicationController
 
   def destroy
     assign = Assign.find(params[:id])
-    #binding.pry
     if current_user.id == assign.user_id || current_user.id == Team.find(assign.team_id).owner.id
       destroy_message = assign_destroy(assign, assign.user)
       redirect_to team_url(params[:team_id]), notice: destroy_message

--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -14,9 +14,11 @@ class AssignsController < ApplicationController
 
   def destroy
     assign = Assign.find(params[:id])
-    destroy_message = assign_destroy(assign, assign.user)
-
-    redirect_to team_url(params[:team_id]), notice: destroy_message
+    #binding.pry
+    if current_user.id == assign.user_id || current_user.id == Team.find(assign.team_id).owner.id
+      destroy_message = assign_destroy(assign, assign.user)
+      redirect_to team_url(params[:team_id]), notice: destroy_message
+    end
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,11 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    if current_user.id != @team.owner.id
+      redirect_to @team
+    end
+  end
 
   def create
     @team = Team.new(team_params)

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
+            <% if current_user.id == @team.owner.id %>
             <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,11 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <td>
+                        <% if current_user.id == assign.user_id || current_user.id == Team.find(assign.team_id).owner.id %>
+                          <%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %>
+                        <% end %>
+                      </td>
                     </tr>
                   <% end %>
                 </tbody>


### PR DESCRIPTION
Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにしました。
TeamのeditはTeamのリーダー（オーナー）のみができるようにしました。